### PR TITLE
refactor the DbDumpImpl struct

### DIFF
--- a/conversion/conversion_helper.go
+++ b/conversion/conversion_helper.go
@@ -93,9 +93,9 @@ func getSeekable(f *os.File) (*os.File, int64, error) {
 func (pdd *ProcessDumpByDialectImpl) ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 	switch driver {
 	case constants.MYSQLDUMP:
-		return common.ProcessDbDump(conv, r, mysql.DbDumpImpl{ExpressionVerificationAccessor: pdd.ExpressionVerificationAccessor}, pdd.DdlVerifier)
+		return common.ProcessDbDump(conv, r, mysql.DbDumpImpl{}, pdd.DdlVerifier, pdd.ExpressionVerificationAccessor)
 	case constants.PGDUMP:
-		return common.ProcessDbDump(conv, r, postgres.DbDumpImpl{ExpressionVerificationAccessor: pdd.ExpressionVerificationAccessor}, pdd.DdlVerifier)
+		return common.ProcessDbDump(conv, r, postgres.DbDumpImpl{}, pdd.DdlVerifier, pdd.ExpressionVerificationAccessor)
 	default:
 		return fmt.Errorf("process dump for driver %s not supported", driver)
 	}

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -70,10 +70,6 @@ func GenerateCheckConstrainstId() string {
 	return GenerateId("cc")
 }
 
-func GenerateCheckConstrainstExprId() string {
-	return GenerateId("expr")
-}
-
 func GenerateRuleId() string {
 	return GenerateId("r")
 }

--- a/sources/common/dbdump.go
+++ b/sources/common/dbdump.go
@@ -23,7 +23,6 @@ import (
 type DbDump interface {
 	GetToDdl() ToDdl
 	ProcessDump(conv *internal.Conv, r *internal.Reader) error
-	GetExpressionVerificationAccessor() expressions_api.ExpressionVerificationAccessor
 }
 
 // ProcessDbDump reads dump data from r and does schema or data conversion,
@@ -31,7 +30,7 @@ type DbDump interface {
 // In schema mode, this method incrementally builds a schema (updating conv).
 // In data mode, this method uses this schema to convert data and writes it
 // to Spanner, using the data sink specified in conv.
-func ProcessDbDump(conv *internal.Conv, r *internal.Reader, dbDump DbDump, ddlVerifier expressions_api.DDLVerifier) error {
+func ProcessDbDump(conv *internal.Conv, r *internal.Reader, dbDump DbDump, ddlVerifier expressions_api.DDLVerifier, exprVerifier expressions_api.ExpressionVerificationAccessor) error {
 	if err := dbDump.ProcessDump(conv, r); err != nil {
 		return err
 	}
@@ -40,7 +39,7 @@ func ProcessDbDump(conv *internal.Conv, r *internal.Reader, dbDump DbDump, ddlVe
 		utilsOrder.initPrimaryKeyOrder(conv)
 		utilsOrder.initIndexOrder(conv)
 		schemaToSpanner := SchemaToSpannerImpl{
-			ExpressionVerificationAccessor: dbDump.GetExpressionVerificationAccessor(),
+			ExpressionVerificationAccessor: exprVerifier,
 			DdlV:                           ddlVerifier,
 		}
 		schemaToSpanner.SchemaToSpannerDDL(conv, dbDump.GetToDdl())

--- a/sources/mysql/infoschema.go
+++ b/sources/mysql/infoschema.go
@@ -344,7 +344,7 @@ func (isi InfoSchemaImpl) processRow(
 	// Case added to handle check constraints
 	case "CHECK":
 		checkClause = collationRegex.ReplaceAllString(checkClause, "")
-		*checkKeys = append(*checkKeys, schema.CheckConstraint{Name: constraintName, Expr: checkClause, ExprId: internal.GenerateCheckConstrainstExprId(), Id: internal.GenerateCheckConstrainstId()})
+		*checkKeys = append(*checkKeys, schema.CheckConstraint{Name: constraintName, Expr: checkClause, ExprId: internal.GenerateExpressionId(), Id: internal.GenerateCheckConstrainstId()})
 	default:
 		m[col] = append(m[col], constraintType)
 	}

--- a/sources/mysql/mysqldump.go
+++ b/sources/mysql/mysqldump.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/expressions_api"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
@@ -54,7 +53,6 @@ var spatialSridRegex = regexp.MustCompile("(?i)\\sSRID\\s\\d*")
 
 // DbDumpImpl MySQL specific implementation for DdlDumpImpl.
 type DbDumpImpl struct {
-	ExpressionVerificationAccessor expressions_api.ExpressionVerificationAccessor
 }
 
 // GetToDdl function below implement the common.DbDump interface.
@@ -65,10 +63,6 @@ func (ddi DbDumpImpl) GetToDdl() common.ToDdl {
 // ProcessDump processes the mysql dump.
 func (ddi DbDumpImpl) ProcessDump(conv *internal.Conv, r *internal.Reader) error {
 	return processMySQLDump(conv, r)
-}
-
-func (ddi DbDumpImpl) GetExpressionVerificationAccessor() expressions_api.ExpressionVerificationAccessor {
-	return ddi.ExpressionVerificationAccessor
 }
 
 // ProcessMySQLDump reads mysqldump data from r and does schema or data conversion,

--- a/sources/mysql/mysqldump.go
+++ b/sources/mysql/mysqldump.go
@@ -342,7 +342,7 @@ func getCheckConstraints(constraints []*ast.Constraint) (checkConstraints []sche
 			checkConstraint := schema.CheckConstraint{
 				Name:   constraint.Name,
 				Expr:   exp,
-				ExprId: internal.GenerateCheckConstrainstExprId(),
+				ExprId: internal.GenerateExpressionId(),
 				Id:     internal.GenerateCheckConstrainstId(),
 			}
 			checkConstraints = append(checkConstraints, checkConstraint)

--- a/sources/mysql/mysqldump_test.go
+++ b/sources/mysql/mysqldump_test.go
@@ -939,16 +939,14 @@ func runProcessMySQLDump(s string) (*internal.Conv, []spannerData) {
 			{Result: true, Err: nil, ExpressionDetail: internal.ExpressionDetail{Expression: "(col1 > 0)", Type: "CHECK", Metadata: map[string]string{"tableId": "t1", "colId": "c1", "checkConstraintName": "check1"}, ExpressionId: "expr1"}},
 		},
 	})
-	mysqlDbDump := DbDumpImpl{
-		ExpressionVerificationAccessor: mockAccessor,
-	}
-	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), mysqlDbDump, &expressions_api.MockDDLVerifier{})
+	mysqlDbDump := DbDumpImpl{}
+	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), mysqlDbDump, &expressions_api.MockDDLVerifier{}, mockAccessor)
 	conv.SetDataMode()
 	var rows []spannerData
 	conv.SetDataSink(func(table string, cols []string, vals []interface{}) {
 		rows = append(rows, spannerData{table: table, cols: cols, vals: vals})
 	})
-	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), mysqlDbDump, &expressions_api.MockDDLVerifier{})
+	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), mysqlDbDump, &expressions_api.MockDDLVerifier{}, mockAccessor)
 	return conv, rows
 }
 

--- a/sources/mysql/report_test.go
+++ b/sources/mysql/report_test.go
@@ -69,7 +69,7 @@ func TestReport(t *testing.T) {
 			{Result: true, Err: nil, ExpressionDetail: internal.ExpressionDetail{Expression: "(col1 > 0)", Type: "CHECK", Metadata: map[string]string{"tableId": "t1", "colId": "c1", "checkConstraintName": "check1"}, ExpressionId: "expr1"}},
 		},
 	})
-	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), DbDumpImpl{ExpressionVerificationAccessor: mockAccessor}, &expressions_api.MockDDLVerifier{})
+	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), DbDumpImpl{}, &expressions_api.MockDDLVerifier{}, mockAccessor)
 	conv.SetDataMode()
 
 	badSchemaTableId, err := internal.GetTableIdFromSpName(conv.SpSchema, "bad_schema")

--- a/sources/postgres/pgdump.go
+++ b/sources/postgres/pgdump.go
@@ -24,7 +24,6 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v5"
 
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/common/constants"
-	"github.com/GoogleCloudPlatform/spanner-migration-tool/expressions_api"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/internal"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/logger"
 	"github.com/GoogleCloudPlatform/spanner-migration-tool/schema"
@@ -32,8 +31,7 @@ import (
 )
 
 // DbDumpImpl Postgres specific implementation for DdlDumpImpl.
-type DbDumpImpl struct{
-	ExpressionVerificationAccessor expressions_api.ExpressionVerificationAccessor
+type DbDumpImpl struct {
 }
 
 type copyOrInsert struct {
@@ -58,11 +56,6 @@ func (ddi DbDumpImpl) GetToDdl() common.ToDdl {
 // ProcessDump calls processPgDump to read a Postgres dump file
 func (ddi DbDumpImpl) ProcessDump(conv *internal.Conv, r *internal.Reader) error {
 	return processPgDump(conv, r)
-}
-
-// GetExpressionVerificationAccessor returns the expression verification accessor
-func (ddi DbDumpImpl) GetExpressionVerificationAccessor() expressions_api.ExpressionVerificationAccessor {
-	return ddi.ExpressionVerificationAccessor
 }
 
 // processPgDump reads pg_dump data from r and does schema or data conversion,

--- a/sources/postgres/report_test.go
+++ b/sources/postgres/report_test.go
@@ -64,7 +64,7 @@ func TestReport(t *testing.T) {
 			{Result: true, Err: nil, ExpressionDetail: internal.ExpressionDetail{Expression: "(col1 > 0)", Type: "CHECK", Metadata: map[string]string{"tableId": "t1", "colId": "c1", "checkConstraintName": "check1"}, ExpressionId: "expr1"}},
 		},
 	})
-	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), DbDumpImpl{ExpressionVerificationAccessor: mockAccessor}, &expressions_api.MockDDLVerifier{})
+	common.ProcessDbDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil), DbDumpImpl{}, &expressions_api.MockDDLVerifier{}, mockAccessor)
 	conv.SetDataMode()
 
 	badSchemaTableId, err := internal.GetTableIdFromSpName(conv.SpSchema, "bad_schema")

--- a/testing/postgres/golden_test.go
+++ b/testing/postgres/golden_test.go
@@ -62,7 +62,7 @@ func TestGoldens(t *testing.T) {
 			err := common.ProcessDbDump(
 				conv,
 				internal.NewReader(bufio.NewReader(strings.NewReader(tc.Input)), nil),
-				postgres.DbDumpImpl{ExpressionVerificationAccessor: mockAccessor}, &expressions_api.MockDDLVerifier{})
+				postgres.DbDumpImpl{}, &expressions_api.MockDDLVerifier{}, mockAccessor)
 			if err != nil {
 				t.Fatalf("error when processing dump %s: %s", tc.Input, err)
 			}


### PR DESCRIPTION
1.  refactor the DbDumpImpl and added expressionAccessor to parameter
2. removed the method GenerateCheckConstrainstExprId

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR