### PR TITLE
added missing parentheses for UI

### DIFF
--- a/webv2/api/schema.go
+++ b/webv2/api/schema.go
@@ -602,15 +602,20 @@ func UpdateCheckConstraint(w http.ResponseWriter, r *http.Request) {
 // checkAndAddParentheses this method will check parentheses  if found it will return same string
 // or add the parentheses then return the string
 func checkAndAddParentheses(checkClause string) string {
-	if strings.HasPrefix(checkClause, "(") && strings.HasSuffix(checkClause, ")") {
-		return checkClause
-	} else if strings.HasPrefix(checkClause, "(") {
-		return checkClause + `)`
-	} else if strings.HasSuffix(checkClause, ")") {
-		return `(` + checkClause
-	} else {
-		return `(` + checkClause + `)`
+	trimmedCheckClause := strings.TrimSpace(checkClause)
+	openCount := strings.Count(trimmedCheckClause, "(")
+	closeCount := strings.Count(trimmedCheckClause, ")")
+
+	if openCount > closeCount {
+		trimmedCheckClause += strings.Repeat(")", openCount-closeCount)
+	} else if closeCount > openCount {
+		trimmedCheckClause = strings.Repeat("(", closeCount-openCount) + trimmedCheckClause
 	}
+
+	if !strings.HasPrefix(trimmedCheckClause, "(") || !strings.HasSuffix(trimmedCheckClause, ")") {
+		trimmedCheckClause = "(" + trimmedCheckClause + ")"
+	}
+	return trimmedCheckClause
 }
 
 // VerifyExpression this function will use expression_api to validate check constraint expressions and add the relevant error

--- a/webv2/api/schema.go
+++ b/webv2/api/schema.go
@@ -582,6 +582,10 @@ func UpdateCheckConstraint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for i := range newCc {
+		newCc[i].Expr = checkAndAddParentheses(newCc[i].Expr)
+	}
+
 	sp := sessionState.Conv.SpSchema[tableId]
 	sp.CheckConstraints = newCc
 	sessionState.Conv.SpSchema[tableId] = sp
@@ -593,6 +597,20 @@ func UpdateCheckConstraint(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(convm)
+}
+
+// checkAndAddParentheses this method will check parentheses  if found it will return same string
+// or add the parentheses then return the string
+func checkAndAddParentheses(checkClause string) string {
+	if strings.HasPrefix(checkClause, "(") && strings.HasSuffix(checkClause, ")") {
+		return checkClause
+	} else if strings.HasPrefix(checkClause, "(") {
+		return checkClause + `)`
+	} else if strings.HasSuffix(checkClause, ")") {
+		return `(` + checkClause
+	} else {
+		return `(` + checkClause + `)`
+	}
 }
 
 // VerifyExpression this function will use expression_api to validate check constraint expressions and add the relevant error

--- a/webv2/api/schema_test.go
+++ b/webv2/api/schema_test.go
@@ -2658,12 +2658,22 @@ func TestUpdateCheckConstraint(t *testing.T) {
 			{Id: "cc1", Name: "check_1", Expr: "(age > 18)", ExprId: "expr1"},
 			{Id: "cc2", Name: "check_2", Expr: "(age < 99)", ExprId: "expr2"},
 			{Id: "cc3", Name: "check_3", Expr: "(age < 150)", ExprId: "expr3"},
+			{Id: "cc4", Name: "check_4", Expr: "((age < 150))", ExprId: "expr4"},
+			{Id: "cc5", Name: "check_5", Expr: "((age < 150))", ExprId: "expr5"},
+			{Id: "cc6", Name: "check_6", Expr: "((age < 150))", ExprId: "expr6"},
+			{Id: "cc7", Name: "check_7", Expr: "((age < 150))", ExprId: "expr7"},
+			{Id: "cc8", Name: "check_8", Expr: "(age < (150))", ExprId: "expr8"},
 		}
 
 		checkConstraints := []schema.CheckConstraint{
 			{Id: "cc1", Name: "check_1", Expr: "age > 18", ExprId: "expr1"},
 			{Id: "cc2", Name: "check_2", Expr: "(age < 99", ExprId: "expr2"},
 			{Id: "cc3", Name: "check_3", Expr: "age < 150)", ExprId: "expr3"},
+			{Id: "cc4", Name: "check_4", Expr: "age < 150))", ExprId: "expr4"},
+			{Id: "cc5", Name: "check_5", Expr: "((age < 150", ExprId: "expr5"},
+			{Id: "cc6", Name: "check_6", Expr: "((age < 150)", ExprId: "expr6"},
+			{Id: "cc7", Name: "check_7", Expr: "(age < 150))", ExprId: "expr7"},
+			{Id: "cc8", Name: "check_8", Expr: "(age < (150)", ExprId: "expr8"},
 		}
 
 		body, err := json.Marshal(checkConstraints)

--- a/webv2/api/schema_test.go
+++ b/webv2/api/schema_test.go
@@ -2657,11 +2657,13 @@ func TestUpdateCheckConstraint(t *testing.T) {
 		expectedCheckConstraint := []ddl.CheckConstraint{
 			{Id: "cc1", Name: "check_1", Expr: "(age > 18)", ExprId: "expr1"},
 			{Id: "cc2", Name: "check_2", Expr: "(age < 99)", ExprId: "expr2"},
+			{Id: "cc3", Name: "check_3", Expr: "(age < 150)", ExprId: "expr3"},
 		}
 
 		checkConstraints := []schema.CheckConstraint{
 			{Id: "cc1", Name: "check_1", Expr: "age > 18", ExprId: "expr1"},
-			{Id: "cc2", Name: "check_2", Expr: "age < 99", ExprId: "expr2"},
+			{Id: "cc2", Name: "check_2", Expr: "(age < 99", ExprId: "expr2"},
+			{Id: "cc3", Name: "check_3", Expr: "age < 150)", ExprId: "expr3"},
 		}
 
 		body, err := json.Marshal(checkConstraints)

--- a/webv2/api/schema_test.go
+++ b/webv2/api/schema_test.go
@@ -2663,6 +2663,7 @@ func TestUpdateCheckConstraint(t *testing.T) {
 			{Id: "cc6", Name: "check_6", Expr: "((age < 150))", ExprId: "expr6"},
 			{Id: "cc7", Name: "check_7", Expr: "((age < 150))", ExprId: "expr7"},
 			{Id: "cc8", Name: "check_8", Expr: "(age < (150))", ExprId: "expr8"},
+			{Id: "cc9", Name: "check_9", Expr: "(age < (150))", ExprId: "expr9"},
 		}
 
 		checkConstraints := []schema.CheckConstraint{
@@ -2674,6 +2675,7 @@ func TestUpdateCheckConstraint(t *testing.T) {
 			{Id: "cc6", Name: "check_6", Expr: "((age < 150)", ExprId: "expr6"},
 			{Id: "cc7", Name: "check_7", Expr: "(age < 150))", ExprId: "expr7"},
 			{Id: "cc8", Name: "check_8", Expr: "(age < (150)", ExprId: "expr8"},
+			{Id: "cc9", Name: "check_9", Expr: "(age < (150) ", ExprId: "expr9"},
 		}
 
 		body, err := json.Marshal(checkConstraints)

--- a/webv2/api/schema_test.go
+++ b/webv2/api/schema_test.go
@@ -2647,6 +2647,43 @@ func TestUpdateCheckConstraint(t *testing.T) {
 		assert.Equal(t, expectedCheckConstraint, updatedSp.CheckConstraints)
 	})
 
+	t.Run("Check Constraints without parentheses", func(t *testing.T) {
+		sessionState := session.GetSessionState()
+		sessionState.Driver = constants.MYSQL
+		sessionState.Conv = internal.MakeConv()
+
+		tableID := "table1"
+
+		expectedCheckConstraint := []ddl.CheckConstraint{
+			{Id: "cc1", Name: "check_1", Expr: "(age > 18)", ExprId: "expr1"},
+			{Id: "cc2", Name: "check_2", Expr: "(age < 99)", ExprId: "expr2"},
+		}
+
+		checkConstraints := []schema.CheckConstraint{
+			{Id: "cc1", Name: "check_1", Expr: "age > 18", ExprId: "expr1"},
+			{Id: "cc2", Name: "check_2", Expr: "age < 99", ExprId: "expr2"},
+		}
+
+		body, err := json.Marshal(checkConstraints)
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest("POST", "update/cc", bytes.NewBuffer(body))
+		assert.NoError(t, err)
+
+		q := req.URL.Query()
+		q.Add("table", tableID)
+		req.URL.RawQuery = q.Encode()
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(api.UpdateCheckConstraint)
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		updatedSp := sessionState.Conv.SpSchema[tableID]
+		assert.Equal(t, expectedCheckConstraint, updatedSp.CheckConstraints)
+	})
+
 	t.Run("ParseError", func(t *testing.T) {
 		sessionState := session.GetSessionState()
 		sessionState.Driver = constants.MYSQL


### PR DESCRIPTION
When a user adds check constraints without parentheses, they are automatically added upon saving.