### PR TITLE
Fix: For session flag added the error handling

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -142,7 +142,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 		err := schemaToSpanner.VerifyExpressions(conv)
 
 		if err != nil {
-			logger.Log.Error(fmt.Sprintf("Error when trying to verify the expression %v", err))
+			logger.Log.Error(fmt.Sprintf("Error while verifying the expressions %v", err))
 			return subcommands.ExitFailure
 		}
 	} else {

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -142,6 +142,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 		err := schemaToSpanner.VerifyExpressions(conv)
 
 		if err != nil {
+			logger.Log.Error(fmt.Sprintf("Error when trying to verify the expression %v", err))
 			return subcommands.ExitFailure
 		}
 	} else {


### PR DESCRIPTION
1. What was the observation?
     1. The schema command with the session flag exited without any error message when Spanner was exhausted,
     providing no related logs for users.
2. How did the issue occur?
   1. During the execution of the schema command with the session flag, the verification API call attempts to create a 
       temporary database. If Spanner is exhausted and cannot fulfil this request, the command silently exits without 
       logging an error.
3. What is the impact?
     1. Users cannot identify or understand the failure due to the lack of error messages or logs when Spanner is exhausted. 
     This can lead to confusion and difficulty in diagnosing the issue.
4. Steps to resolve the above problem:
    1. Modified the schema command flow to exit with a detailed error message indicating the cause of failure.
    2. Added logging functionality to ensure users receive appropriate logs when the command exits due to Spanner 
    exhaustion or any other errors.
